### PR TITLE
Checkpointstore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>1.3.3.BUILD-SNAPSHOT</version>
+		<version>1.3.5.RELEASE</version>
 		<relativePath/>
 	</parent>
 

--- a/spring-cloud-stream-binder-kinesis-core/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/CheckpointProperties.java
+++ b/spring-cloud-stream-binder-kinesis-core/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/CheckpointProperties.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.kinesis.properties;
+
+/**
+ * 
+ * @author Peter Oates
+ *
+ */
+public class CheckpointProperties {
+
+	private String checkpointTable = "checkpoint";
+
+	private Long dynamoDbReadCapacity = 1L;
+
+	private Long dynamoDbWriteCapacity = 1L;
+
+	public String getCheckpointTable() {
+		return checkpointTable;
+	}
+
+	public void setCheckpointTable(String checkpointTable) {
+		this.checkpointTable = checkpointTable;
+	}
+
+	public Long getDynamoDbReadCapacity() {
+		return dynamoDbReadCapacity;
+	}
+
+	public void setDynamoDbReadCapacity(Long dynamoDbReadCapacity) {
+		this.dynamoDbReadCapacity = dynamoDbReadCapacity;
+	}
+
+	public Long getDynamoDbWriteCapacity() {
+		return dynamoDbWriteCapacity;
+	}
+
+	public void setDynamoDbWriteCapacity(Long dynamoDbWriteCapacity) {
+		this.dynamoDbWriteCapacity = dynamoDbWriteCapacity;
+	}
+	
+}

--- a/spring-cloud-stream-binder-kinesis-core/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/KinesisBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binder-kinesis-core/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/KinesisBinderConfigurationProperties.java
@@ -31,8 +31,12 @@ public class KinesisBinderConfigurationProperties {
 	private int describeStreamBackoff = 1000;
 
 	private int describeStreamRetries = 50;
-	
-	private String checkpointName = null;
+
+	private String checkpointTable = null;
+
+	private Long dynamoDbReadCapacity = 1L;
+
+	private Long dynamoDbWriteCapacity = 1L;
 
 	public String[] getHeaders() {
 		return this.headers;
@@ -58,11 +62,27 @@ public class KinesisBinderConfigurationProperties {
 		this.describeStreamRetries = describeStreamRetries;
 	}
 
-	public String getCheckpointName() {
-		return checkpointName;
+	public String getCheckpointTable() {
+		return checkpointTable;
 	}
 
-	public void setCheckpointName(String checkpointName) {
-		this.checkpointName = checkpointName;
+	public void setCheckpointTable(String checkpointTable) {
+		this.checkpointTable = checkpointTable;
+	}
+
+	public Long getDynamoDbReadCapacity() {
+		return dynamoDbReadCapacity;
+	}
+
+	public void setDynamoDbReadCapacity(Long dynamoDbReadCapacity) {
+		this.dynamoDbReadCapacity = dynamoDbReadCapacity;
+	}
+
+	public Long getDynamoDbWriteCapacity() {
+		return dynamoDbWriteCapacity;
+	}
+
+	public void setDynamoDbWriteCapacity(Long dynamoDbWriteCapacity) {
+		this.dynamoDbWriteCapacity = dynamoDbWriteCapacity;
 	}
 }

--- a/spring-cloud-stream-binder-kinesis-core/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/KinesisBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binder-kinesis-core/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/KinesisBinderConfigurationProperties.java
@@ -31,12 +31,8 @@ public class KinesisBinderConfigurationProperties {
 	private int describeStreamBackoff = 1000;
 
 	private int describeStreamRetries = 50;
-
-	private String checkpointTable = null;
-
-	private Long dynamoDbReadCapacity = 1L;
-
-	private Long dynamoDbWriteCapacity = 1L;
+	
+	private CheckpointProperties checkpoint = new CheckpointProperties();
 
 	public String[] getHeaders() {
 		return this.headers;
@@ -62,27 +58,11 @@ public class KinesisBinderConfigurationProperties {
 		this.describeStreamRetries = describeStreamRetries;
 	}
 
-	public String getCheckpointTable() {
-		return checkpointTable;
+	public CheckpointProperties getCheckpoint() {
+		return checkpoint;
 	}
 
-	public void setCheckpointTable(String checkpointTable) {
-		this.checkpointTable = checkpointTable;
-	}
-
-	public Long getDynamoDbReadCapacity() {
-		return dynamoDbReadCapacity;
-	}
-
-	public void setDynamoDbReadCapacity(Long dynamoDbReadCapacity) {
-		this.dynamoDbReadCapacity = dynamoDbReadCapacity;
-	}
-
-	public Long getDynamoDbWriteCapacity() {
-		return dynamoDbWriteCapacity;
-	}
-
-	public void setDynamoDbWriteCapacity(Long dynamoDbWriteCapacity) {
-		this.dynamoDbWriteCapacity = dynamoDbWriteCapacity;
+	public void setCheckpoint(CheckpointProperties checkpoint) {
+		this.checkpoint = checkpoint;
 	}
 }

--- a/spring-cloud-stream-binder-kinesis-core/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/KinesisBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binder-kinesis-core/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/KinesisBinderConfigurationProperties.java
@@ -31,6 +31,8 @@ public class KinesisBinderConfigurationProperties {
 	private int describeStreamBackoff = 1000;
 
 	private int describeStreamRetries = 50;
+	
+	private String checkpointName = null;
 
 	public String[] getHeaders() {
 		return this.headers;
@@ -54,5 +56,13 @@ public class KinesisBinderConfigurationProperties {
 
 	public void setDescribeStreamRetries(int describeStreamRetries) {
 		this.describeStreamRetries = describeStreamRetries;
+	}
+
+	public String getCheckpointName() {
+		return checkpointName;
+	}
+
+	public void setCheckpointName(String checkpointName) {
+		this.checkpointName = checkpointName;
 	}
 }

--- a/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
@@ -59,6 +59,21 @@ For general binding configuration options and properties, please refer to the ht
 [[kinesis-binder-properties]]
 === Kinesis Binder Properties
 
+Checkpoint properties prefixed with `spring.cloud.strea.kinesis.binder.checkpoint` 
+
+checkpointTable::
+	The name to give the DynamoDb table 
++            
+Default: `checkpoint`
+dynamoDbReadCapacity::
+	The Read capacity of the DynamoDb table. See [AWS docunmentation](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ProvisionedThroughput.html)
++
+Default: `1`
+dynamoDbWriteCapacity::
+	The write capacity of the DynamoDb table. See [AWS docunmentation](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ProvisionedThroughput.html)
++
+Default: `1`
+
 === Kinesis Consumer Properties
 
 The following properties are available for Kinesis consumers only and must be prefixed with `spring.cloud.stream.kinesis.bindings.<channelName>.consumer.`.

--- a/spring-cloud-stream-binder-kinesis/pom.xml
+++ b/spring-cloud-stream-binder-kinesis/pom.xml
@@ -32,6 +32,10 @@
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-aws</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk-dynamodb</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>

--- a/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/KinesisMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/KinesisMessageChannelBinder.java
@@ -65,8 +65,8 @@ public class KinesisMessageChannelBinder extends
 	private KinesisExtendedBindingProperties extendedBindingProperties = new KinesisExtendedBindingProperties();
 
 	private final AmazonKinesisAsync amazonKinesis;
-	
-	private MetadataStore metaDataStore;
+
+	private MetadataStore metadataStore;
 
 	public KinesisMessageChannelBinder(AmazonKinesisAsync amazonKinesis,
 			KinesisBinderConfigurationProperties configurationProperties,
@@ -81,8 +81,7 @@ public class KinesisMessageChannelBinder extends
 		Assert.notNull(configurationProperties, "'configurationProperties' must not be null");
 		if (ObjectUtils.isEmpty(configurationProperties.getHeaders())) {
 			return BinderHeaders.STANDARD_HEADERS;
-		}
-		else {
+		} else {
 			String[] combinedHeadersToMap = Arrays.copyOfRange(BinderHeaders.STANDARD_HEADERS, 0,
 					BinderHeaders.STANDARD_HEADERS.length + configurationProperties.getHeaders().length);
 			System.arraycopy(configurationProperties.getHeaders(), 0, combinedHeadersToMap,
@@ -113,7 +112,8 @@ public class KinesisMessageChannelBinder extends
 		kinesisMessageHandler.setSync(producerProperties.getExtension().isSync());
 		kinesisMessageHandler.setStream(destination.getName());
 		if (producerProperties.isPartitioned()) {
-			kinesisMessageHandler.setPartitionKeyExpressionString("'partitionKey-' + headers." + BinderHeaders.PARTITION_HEADER);
+			kinesisMessageHandler
+					.setPartitionKeyExpressionString("'partitionKey-' + headers." + BinderHeaders.PARTITION_HEADER);
 		}
 		kinesisMessageHandler.setBeanFactory(getBeanFactory());
 
@@ -142,8 +142,7 @@ public class KinesisMessageChannelBinder extends
 
 		if (shardOffsets == null) {
 			adapter = new KinesisMessageDrivenChannelAdapter(this.amazonKinesis, destination.getName());
-		}
-		else {
+		} else {
 			adapter = new KinesisMessageDrivenChannelAdapter(this.amazonKinesis,
 					shardOffsets.toArray(new KinesisShardOffset[shardOffsets.size()]));
 		}
@@ -153,11 +152,11 @@ public class KinesisMessageChannelBinder extends
 		adapter.setConsumerGroup(consumerGroup);
 
 		adapter.setStreamInitialSequence(anonymous ? KinesisShardOffset.latest() : KinesisShardOffset.trimHorizon());
-		
+
 		adapter.setListenerMode(ListenerMode.record);
-		adapter.setCheckpointMode(CheckpointMode.record); 		
-		adapter.setCheckpointStore(metaDataStore);
-		
+		adapter.setCheckpointMode(CheckpointMode.record);
+		adapter.setCheckpointStore(metadataStore);
+
 		adapter.setConcurrency(properties.getConcurrency());
 		adapter.setStartTimeout(properties.getExtension().getStartTimeout());
 		adapter.setDescribeStreamBackoff(this.configurationProperties.getDescribeStreamBackoff());
@@ -169,12 +168,8 @@ public class KinesisMessageChannelBinder extends
 		return adapter;
 	}
 
-	public MetadataStore getMetaDataStore() {
-		return metaDataStore;
-	}
-
-	public void setMetaDataStore(MetadataStore metaDataStore) {
-		this.metaDataStore = metaDataStore;
+	public void setMetadataStore(MetadataStore metadataStore) {
+		this.metadataStore = metadataStore;
 	}
 
 }

--- a/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/KinesisMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/KinesisMessageChannelBinder.java
@@ -81,7 +81,8 @@ public class KinesisMessageChannelBinder extends
 		Assert.notNull(configurationProperties, "'configurationProperties' must not be null");
 		if (ObjectUtils.isEmpty(configurationProperties.getHeaders())) {
 			return BinderHeaders.STANDARD_HEADERS;
-		} else {
+		}
+		else {
 			String[] combinedHeadersToMap = Arrays.copyOfRange(BinderHeaders.STANDARD_HEADERS, 0,
 					BinderHeaders.STANDARD_HEADERS.length + configurationProperties.getHeaders().length);
 			System.arraycopy(configurationProperties.getHeaders(), 0, combinedHeadersToMap,
@@ -142,7 +143,8 @@ public class KinesisMessageChannelBinder extends
 
 		if (shardOffsets == null) {
 			adapter = new KinesisMessageDrivenChannelAdapter(this.amazonKinesis, destination.getName());
-		} else {
+		}
+		else {
 			adapter = new KinesisMessageDrivenChannelAdapter(this.amazonKinesis,
 					shardOffsets.toArray(new KinesisShardOffset[shardOffsets.size()]));
 		}

--- a/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/config/KinesisBinderConfiguration.java
+++ b/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/config/KinesisBinderConfiguration.java
@@ -36,7 +36,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.aws.metadata.DynamoDbMetaDataStore;
 import org.springframework.integration.codec.Codec;
 import org.springframework.integration.metadata.MetadataStore;
-import org.springframework.integration.metadata.SimpleMetadataStore;
 
 /**
  *
@@ -81,23 +80,20 @@ public class KinesisBinderConfiguration {
 	@ConditionalOnMissingBean
 	MetadataStore kinesisCheckpointStore(AWSCredentialsProvider awsCredentialsProvider, RegionProvider regionProvider) {
 
-		String tableName = this.configurationProperties.getCheckpointTable();
+		String tableName = this.configurationProperties.getCheckpoint().getCheckpointTable();
 
 		MetadataStore kinesisCheckpointStore;
-		if (tableName != null) {
-			AmazonDynamoDBAsync dynamoDB = AmazonDynamoDBAsyncClientBuilder.standard()
+		AmazonDynamoDBAsync dynamoDB = AmazonDynamoDBAsyncClientBuilder.standard()
 					.withCredentials(awsCredentialsProvider)
 					.withRegion(regionProvider.getRegion().getName())
 					.build();
 
-			kinesisCheckpointStore = new DynamoDbMetaDataStore(dynamoDB, tableName);
-			((DynamoDbMetaDataStore) kinesisCheckpointStore)
-					.setReadCapacity(configurationProperties.getDynamoDbReadCapacity());
-			((DynamoDbMetaDataStore) kinesisCheckpointStore)
-					.setWriteCapacity(configurationProperties.getDynamoDbWriteCapacity());
-		} else {
-			kinesisCheckpointStore = new SimpleMetadataStore();
-		}
+		kinesisCheckpointStore = new DynamoDbMetaDataStore(dynamoDB, tableName);
+		((DynamoDbMetaDataStore) kinesisCheckpointStore)
+				.setReadCapacity(configurationProperties.getCheckpoint().getDynamoDbReadCapacity());
+		((DynamoDbMetaDataStore) kinesisCheckpointStore)
+				.setWriteCapacity(configurationProperties.getCheckpoint().getDynamoDbWriteCapacity());
+
 
 		return kinesisCheckpointStore;
 	}


### PR DESCRIPTION
Resolves spring-cloud/spring-cloud-stream-binder-aws-kinesis#18

Implementation of DynamoDBMetadataStore. Adds a new property 

`spring.cloud.stream.kinesis.binder.checkpointName` 

If this property is set then a `DynamoDBMetadataStore` will be created, otherwise the `SimpleMetdataStore` will be used.

There is one remaining issue, on first start where a DynamoDB table must be created an error can be raised. I believe this is due to the Waiter within spring-integration-aws `DynamoDbMetaDataStore` 

This waits for 25 seconds which is sometimes not long enough for the DynamoDB table to become active. 

