### PR TITLE
Implementing shard updating

### DIFF
--- a/spring-cloud-stream-binder-kinesis-core/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/KinesisBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binder-kinesis-core/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/KinesisBinderConfigurationProperties.java
@@ -22,6 +22,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *
  * @author Peter Oates
  * @author Artem Bilan
+ * @author Jacob Severson
  *
  */
 @ConfigurationProperties(prefix = "spring.cloud.stream.kinesis.binder")
@@ -32,6 +33,10 @@ public class KinesisBinderConfigurationProperties {
 	private int describeStreamBackoff = 1000;
 
 	private int describeStreamRetries = 50;
+
+	private boolean autoAddShards = false;
+
+	private int minShardCount = 1;
 
 	private Checkpoint checkpoint = new Checkpoint();
 
@@ -59,6 +64,22 @@ public class KinesisBinderConfigurationProperties {
 		this.describeStreamRetries = describeStreamRetries;
 	}
 
+	public boolean isAutoAddShards() {
+		return this.autoAddShards;
+	}
+
+	public void setAutoAddShards(boolean autoAddShards) {
+		this.autoAddShards = autoAddShards;
+	}
+
+	public int getMinShardCount() {
+		return minShardCount;
+	}
+
+	public void setMinShardCount(int minShardCount) {
+		this.minShardCount = minShardCount;
+	}
+
 	public Checkpoint getCheckpoint() {
 		return this.checkpoint;
 	}
@@ -74,6 +95,10 @@ public class KinesisBinderConfigurationProperties {
 		private long readCapacity = 1L;
 
 		private long writeCapacity = 1L;
+
+		private int createTableDelay = 1;
+
+		private int createTableRetries = 25;
 
 		public String getTable() {
 			return this.table;
@@ -99,6 +124,21 @@ public class KinesisBinderConfigurationProperties {
 			this.writeCapacity = writeCapacity;
 		}
 
+		public int getCreateTableDelay() {
+			return createTableDelay;
+		}
+
+		public void setCreateTableDelay(int createTableDelay) {
+			this.createTableDelay = createTableDelay;
+		}
+
+		public int getCreateTableRetries() {
+			return createTableRetries;
+		}
+
+		public void setCreateTableRetries(int createTableRetries) {
+			this.createTableRetries = createTableRetries;
+		}
 	}
 
 }

--- a/spring-cloud-stream-binder-kinesis-core/src/test/java/org/springframework/cloud/stream/binder/kinesis/provisioning/KinesisStreamProvisionerTests.java
+++ b/spring-cloud-stream-binder-kinesis-core/src/test/java/org/springframework/cloud/stream/binder/kinesis/provisioning/KinesisStreamProvisionerTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.stream.binder.kinesis.provisioning;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -24,11 +25,14 @@ import com.amazonaws.services.kinesis.model.CreateStreamResult;
 import com.amazonaws.services.kinesis.model.DescribeStreamRequest;
 import com.amazonaws.services.kinesis.model.DescribeStreamResult;
 import com.amazonaws.services.kinesis.model.ResourceNotFoundException;
+import com.amazonaws.services.kinesis.model.ScalingType;
 import com.amazonaws.services.kinesis.model.Shard;
 import com.amazonaws.services.kinesis.model.StreamDescription;
 import com.amazonaws.services.kinesis.model.StreamStatus;
+import com.amazonaws.services.kinesis.model.UpdateShardCountRequest;
 
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
@@ -70,6 +74,7 @@ public class KinesisStreamProvisionerTests {
 
 		verify(amazonKinesisMock)
 				.describeStream(any(DescribeStreamRequest.class));
+
 		assertThat(destination.getName()).isEqualTo(name);
 	}
 
@@ -96,7 +101,44 @@ public class KinesisStreamProvisionerTests {
 
 		verify(amazonKinesisMock)
 				.describeStream(any(DescribeStreamRequest.class));
+
 		assertThat(destination.getName()).isEqualTo(name);
+	}
+
+	@Test
+	public void testProvisionConsumerExistingStreamUpdateShards() {
+		AmazonKinesis amazonKinesisMock = mock(AmazonKinesis.class);
+		ArgumentCaptor<UpdateShardCountRequest> updateShardCaptor =
+				ArgumentCaptor.forClass(UpdateShardCountRequest.class);
+		String name = "test-stream";
+		String group = "test-group";
+		int targetShardCount = 2;
+		KinesisBinderConfigurationProperties binderProperties = new KinesisBinderConfigurationProperties();
+		binderProperties.setMinShardCount(targetShardCount);
+		binderProperties.setAutoAddShards(true);
+		KinesisStreamProvisioner provisioner = new KinesisStreamProvisioner(amazonKinesisMock, binderProperties);
+
+		ExtendedConsumerProperties<KinesisConsumerProperties> extendedConsumerProperties =
+				new ExtendedConsumerProperties<>(new KinesisConsumerProperties());
+
+		DescribeStreamResult describeOriginalStream =
+				describeStreamResultWithShards(Collections.singletonList(new Shard()));
+
+		DescribeStreamResult describeUpdatedStream =
+				describeStreamResultWithShards(Arrays.asList(new Shard(), new Shard()));
+
+		when(amazonKinesisMock.describeStream(any(DescribeStreamRequest.class)))
+				.thenReturn(describeOriginalStream)
+				.thenReturn(describeUpdatedStream);
+
+		provisioner.provisionConsumerDestination(name, group, extendedConsumerProperties);
+
+		verify(amazonKinesisMock, times(1))
+				.updateShardCount(updateShardCaptor.capture());
+
+		assertThat(updateShardCaptor.getValue().getStreamName()).isEqualTo(name);
+		assertThat(updateShardCaptor.getValue().getScalingType()).isEqualTo(ScalingType.UNIFORM_SCALING.name());
+		assertThat(updateShardCaptor.getValue().getTargetShardCount()).isEqualTo(targetShardCount);
 	}
 
 	@Test
@@ -132,6 +174,40 @@ public class KinesisStreamProvisionerTests {
 	}
 
 	@Test
+	public void testProvisionProducerUpdateShards() {
+		AmazonKinesis amazonKinesisMock = mock(AmazonKinesis.class);
+		ArgumentCaptor<UpdateShardCountRequest> updateShardCaptor = ArgumentCaptor.forClass(UpdateShardCountRequest.class);
+		String name = "test-stream";
+		String group = "test-group";
+		int targetShardCount = 2;
+		KinesisBinderConfigurationProperties binderProperties = new KinesisBinderConfigurationProperties();
+		binderProperties.setMinShardCount(targetShardCount);
+		binderProperties.setAutoAddShards(true);
+		KinesisStreamProvisioner provisioner = new KinesisStreamProvisioner(amazonKinesisMock, binderProperties);
+
+		ExtendedConsumerProperties<KinesisConsumerProperties> extendedConsumerProperties =
+				new ExtendedConsumerProperties<>(new KinesisConsumerProperties());
+
+		DescribeStreamResult describeOriginalStream =
+				describeStreamResultWithShards(Collections.singletonList(new Shard()));
+
+		DescribeStreamResult describeUpdatedStream =
+				describeStreamResultWithShards(Arrays.asList(new Shard(), new Shard()));
+
+		when(amazonKinesisMock.describeStream(any(DescribeStreamRequest.class)))
+				.thenReturn(describeOriginalStream)
+				.thenReturn(describeUpdatedStream);
+
+		provisioner.provisionConsumerDestination(name, group, extendedConsumerProperties);
+
+		verify(amazonKinesisMock, times(1))
+				.updateShardCount(updateShardCaptor.capture());
+		assertThat(updateShardCaptor.getValue().getStreamName()).isEqualTo(name);
+		assertThat(updateShardCaptor.getValue().getScalingType()).isEqualTo(ScalingType.UNIFORM_SCALING.name());
+		assertThat(updateShardCaptor.getValue().getTargetShardCount()).isEqualTo(targetShardCount);
+	}
+
+	@Test
 	public void testProvisionConsumerSuccessfulWithNewStream() {
 		AmazonKinesis amazonKinesisMock = mock(AmazonKinesis.class);
 		KinesisBinderConfigurationProperties binderProperties = new KinesisBinderConfigurationProperties();
@@ -153,7 +229,7 @@ public class KinesisStreamProvisionerTests {
 
 		when(amazonKinesisMock.describeStream(any(DescribeStreamRequest.class)))
 				.thenThrow(new ResourceNotFoundException("I got nothing"))
-				.thenReturn(describeStreamResult);;
+				.thenReturn(describeStreamResult);
 
 		when(amazonKinesisMock.createStream(name, instanceCount * concurrency))
 				.thenReturn(new CreateStreamResult());

--- a/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
@@ -69,6 +69,14 @@ describeStreamRetries::
   The amount of times the consumer will retry a `DescribeStream` operation waiting for the stream to be in `ACTIVE` state
 +
 Default: `50`.
+autoAddShards::
+    If set to `true`, the binder will create new shards automatically. If set to `false`, the binder will rely on the shard size of the stream being already configured. If the shard count of the target stream is smaller than the expected value, the binder will ignore that value.
++
+Default: `false`
+minShardCount::
+    Effective only if `autoAddShards` is set to `true`. The minimum number of shards that the binder will configure on the stream from which it produces/consumes data. It can be superseded by the partitionCount setting of the producer or by the value of instanceCount * concurrency settings of the producer (if either is larger).
++
+Default: `1`
 
 The based on the DynamoDB Checkpoint properties prefixed with `spring.cloud.stream.kinesis.binder.checkpoint`
 
@@ -76,6 +84,14 @@ table::
 	The name to give the DynamoDb table
 +
 Default: `checkpoint`
+createTableDelay::
+    The amount of time in seconds between each polling attempt while waiting for the checkpoint DynamoDB table to be created
++
+Default: `1`
+createTableRetries::
+    The amount of times the consumer will poll DynamoDB while waiting for the checkpoint table to be created.
++
+Default: `25`
 readCapacity::
 	The Read capacity of the DynamoDb table.
 See http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ProvisionedThroughput.html[Kinesis Provisioned Throughput]

--- a/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/KinesisMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/KinesisMessageChannelBinder.java
@@ -55,6 +55,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Peter Oates
  * @author Artem Bilan
+ *
  */
 public class KinesisMessageChannelBinder extends
 		AbstractMessageChannelBinder<ExtendedConsumerProperties<KinesisConsumerProperties>, ExtendedProducerProperties<KinesisProducerProperties>, KinesisStreamProvisioner>

--- a/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/config/KinesisBinderConfiguration.java
+++ b/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/config/KinesisBinderConfiguration.java
@@ -93,6 +93,8 @@ public class KinesisBinderConfiguration {
 		DynamoDbMetaDataStore kinesisCheckpointStore = new DynamoDbMetaDataStore(dynamoDB, tableName);
 		kinesisCheckpointStore.setReadCapacity(this.configurationProperties.getCheckpoint().getReadCapacity());
 		kinesisCheckpointStore.setWriteCapacity(this.configurationProperties.getCheckpoint().getWriteCapacity());
+		kinesisCheckpointStore.setCreateTableDelay(this.configurationProperties.getCheckpoint().getCreateTableDelay());
+		kinesisCheckpointStore.setCreateTableRetries(this.configurationProperties.getCheckpoint().getCreateTableRetries());
 
 		return kinesisCheckpointStore;
 	}


### PR DESCRIPTION
Adding the ability for the binder to automatically create shards on startup if the current stream's count is less than what is desired. The properties that control this functionality and their defaults are as follows

```
spring.cloud.stream.kinesis.binder.autoAddShards=false
spring.cloud.stream.kinesis.binder.minShardCount=1
```

* Added the `autoAddShards` and `minShardCount` properties and code to update stream shard count

* Added the `createTableDelay` and `createTableRetries` properties to the checkpoint configuration

* Added documentation entries for the new properties