### PR TITLE
Exposing Consumer and Producer properties

### DIFF
--- a/spring-cloud-stream-binder-kinesis-core/pom.xml
+++ b/spring-cloud-stream-binder-kinesis-core/pom.xml
@@ -18,6 +18,10 @@
 			<artifactId>spring-cloud-stream</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.integration</groupId>
+			<artifactId>spring-integration-aws</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-kinesis</artifactId>
 		</dependency>

--- a/spring-cloud-stream-binder-kinesis-core/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/KinesisConsumerProperties.java
+++ b/spring-cloud-stream-binder-kinesis-core/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/KinesisConsumerProperties.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.stream.binder.kinesis.properties;
 
+import org.springframework.integration.aws.inbound.kinesis.CheckpointMode;
+import org.springframework.integration.aws.inbound.kinesis.ListenerMode;
+
 /**
  * 
  * @author Peter Oates
@@ -26,6 +29,16 @@ public class KinesisConsumerProperties {
 
 	private int startTimeout = 60000;
 
+	private ListenerMode listenerMode = ListenerMode.record;
+
+	private CheckpointMode checkpointMode = CheckpointMode.batch;
+
+	private int recordsLimit = 10000;
+
+	private int idleBetweenPolls = 1000;
+
+	private int consumerBackoff = 1000;
+
 	public int getStartTimeout() {
 		return this.startTimeout;
 	}
@@ -34,4 +47,43 @@ public class KinesisConsumerProperties {
 		this.startTimeout = startTimeout;
 	}
 
+	public ListenerMode getListenerMode() {
+		return this.listenerMode;
+	}
+
+	public void setListenerMode(ListenerMode listenerMode) {
+		this.listenerMode = listenerMode;
+	}
+
+	public CheckpointMode getCheckpointMode() {
+		return this.checkpointMode;
+	}
+
+	public void setCheckpointMode(CheckpointMode checkpointMode) {
+		this.checkpointMode = checkpointMode;
+	}
+
+	public int getRecordsLimit() {
+		return this.recordsLimit;
+	}
+
+	public void setRecordsLimit(int recordsLimit) {
+		this.recordsLimit = recordsLimit;
+	}
+
+	public int getIdleBetweenPolls() {
+		return this.idleBetweenPolls;
+	}
+
+	public void setIdleBetweenPolls(int idleBetweenPolls) {
+		this.idleBetweenPolls = idleBetweenPolls;
+	}
+
+	public int getConsumerBackoff() {
+		return this.consumerBackoff;
+	}
+
+	public void setConsumerBackoff(int consumerBackoff) {
+		this.consumerBackoff = consumerBackoff;
+	}
 }

--- a/spring-cloud-stream-binder-kinesis-core/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/KinesisProducerProperties.java
+++ b/spring-cloud-stream-binder-kinesis-core/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/KinesisProducerProperties.java
@@ -19,11 +19,14 @@ package org.springframework.cloud.stream.binder.kinesis.properties;
 /**
  * 
  * @author Peter Oates
+ * @author Jacob Severson
  *
  */
 public class KinesisProducerProperties {
 
 	private boolean sync;
+
+	private long sendTimeout = 10000;
 
 	public void setSync(boolean sync) {
 		this.sync = sync;
@@ -33,4 +36,11 @@ public class KinesisProducerProperties {
 		return this.sync;
 	}
 
+	public long getSendTimeout() {
+		return sendTimeout;
+	}
+
+	public void setSendTimeout(long sendTimeout) {
+		this.sendTimeout = sendTimeout;
+	}
 }

--- a/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
@@ -115,10 +115,44 @@ startTimeout::
   The amount of time to wait for the consumer to start, in milliseconds.
 +
 Default: `60000`.
+listenerMode::
+  The mode in which records are processed. If `record`, each `Message` will be converted from a single `Record`. If `batch`,
+  each `Message` will container a `List<Record>`.
++
+Default: `record`
+checkpointMode::
+  The mode in which checkpoints are updated. If `record`, checkpoints occur after each record is processed (but this option
+  is only effective if `listenerMode` is set to `record`). If `batch`, checkpoints occur after each batch of records is
+  processed. If `manual`, checkpoints occur on demand via the `Checkpointer` callback.
++
+Default: `batch`
+recordsLimit::
+  The maximum number of records to poll per `GetRecords` request. Must not be greater than `10000`.
++
+Default: `10000`
+idleBetweenPolls::
+  The sleep interval used in the main loop between shards polling cycles, in milliseconds. Must not be less than `250`
++
+Default: `1000`
+consumerBackoff::
+  The amount of time the consumer will wait to attempt another `GetRecords` operation after a read with no results, in milliseconds.
++
+Default: `1000`
 
 
 === Kinesis Producer Properties
 
 The following properties are available for Kinesis producers only and must be prefixed with `spring.cloud.stream.kinesis.bindings.<channelName>.producer.`
+
+sync::
+  Whether the producer should act in a synchronous manner with respect to writing records into a stream. If true, the producer will
+  wait for a response from Kinesis after a `PutRecord` operation.
++
+Default: `false`
+sendTimeout::
+  Effective only if `sync` is set to `true`. The amount of time to wait for a response from Kinesis after a `PutRecord` operation, in milliseconds.
++
+Default: `10000`
+
 
 

--- a/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/KinesisMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/KinesisMessageChannelBinder.java
@@ -38,10 +38,8 @@ import org.springframework.cloud.stream.binder.kinesis.provisioning.KinesisConsu
 import org.springframework.cloud.stream.binder.kinesis.provisioning.KinesisStreamProvisioner;
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.cloud.stream.provisioning.ProducerDestination;
-import org.springframework.integration.aws.inbound.kinesis.CheckpointMode;
 import org.springframework.integration.aws.inbound.kinesis.KinesisMessageDrivenChannelAdapter;
 import org.springframework.integration.aws.inbound.kinesis.KinesisShardOffset;
-import org.springframework.integration.aws.inbound.kinesis.ListenerMode;
 import org.springframework.integration.aws.outbound.KinesisMessageHandler;
 import org.springframework.integration.core.MessageProducer;
 import org.springframework.integration.metadata.MetadataStore;
@@ -113,6 +111,7 @@ public class KinesisMessageChannelBinder extends
 
 		KinesisMessageHandler kinesisMessageHandler = new KinesisMessageHandler(this.amazonKinesis);
 		kinesisMessageHandler.setSync(producerProperties.getExtension().isSync());
+		kinesisMessageHandler.setSendTimeout(producerProperties.getExtension().getSendTimeout());
 		kinesisMessageHandler.setStream(destination.getName());
 		if (producerProperties.isPartitioned()) {
 			kinesisMessageHandler
@@ -157,8 +156,11 @@ public class KinesisMessageChannelBinder extends
 
 		adapter.setStreamInitialSequence(anonymous ? KinesisShardOffset.latest() : KinesisShardOffset.trimHorizon());
 
-		adapter.setListenerMode(ListenerMode.record);
-		adapter.setCheckpointMode(CheckpointMode.record);
+		adapter.setListenerMode(properties.getExtension().getListenerMode());
+		adapter.setCheckpointMode(properties.getExtension().getCheckpointMode());
+		adapter.setRecordsLimit(properties.getExtension().getRecordsLimit());
+		adapter.setIdleBetweenPolls(properties.getExtension().getIdleBetweenPolls());
+		adapter.setConsumerBackoff(properties.getExtension().getConsumerBackoff());
 
 		if (this.checkpointStore != null) {
 			adapter.setCheckpointStore(this.checkpointStore);


### PR DESCRIPTION
This PR allows further configuration of Consumer and Producer behavior by exposing the following properties:

### Producer
* `sendTimeout`

### Consumer
* `listenerMode`
* `checkpointMode`
* `recordsLimit`
* `idleBetweenPolls`
* `consumerBackoff`

Resolves #9