### PR TITLE
Error channel configuration

### DIFF
--- a/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
@@ -158,12 +158,12 @@ Default: `10000`
 [[kinesis-error-channels]]
 == Error Channels
 
-The binder can be configured to send producer exceptions to an error channel. See <<binder-error-channels>> for more information.
+The binder can be configured to send producer exceptions to an error channel. See https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/#_spring_integration_error_channel_support[the section on Spring Cloud error support] for more information.
 
 The payload of the `ErrorMessage` for a send failure is an `AwsRequestFailureException` with properties:
 
 * `failedMessage` - the spring-messaging `Message<?>` that failed to be sent.
-* `request` - the raw `AmazonWebServiceRequest` (either `PutRecordRequest` or `PutRecordsRequest`) that was created from the `failedMessage`
+* `request` - the raw `AmazonWebServiceRequest` (either `PutRecordRequest` or `PutRecordsRequest`) that was created from the `failedMessage`.
 
 There is no automatic handling of these exceptions (such as sending to a dead letter queue), but you can consume these exceptions with your own Spring Integration flow.
 

--- a/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
@@ -155,4 +155,15 @@ sendTimeout::
 Default: `10000`
 
 
+[[kinesis-error-channels]]
+== Error Channels
+
+The binder can be configured to send producer exceptions to an error channel. See <<binder-error-channels>> for more information.
+
+The payload of the `ErrorMessage` for a send failure is an `AwsRequestFailureException` with properties:
+
+* `failedMessage` - the spring-messaging `Message<?>` that failed to be sent.
+* `request` - the raw `AmazonWebServiceRequest` (either `PutRecordRequest` or `PutRecordsRequest`) that was created from the `failedMessage`
+
+There is no automatic handling of these exceptions (such as sending to a dead letter queue), but you can consume these exceptions with your own Spring Integration flow.
 

--- a/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
@@ -158,7 +158,7 @@ Default: `10000`
 [[kinesis-error-channels]]
 == Error Channels
 
-The binder can be configured to send producer exceptions to an error channel. See https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/#_spring_integration_error_channel_support[the section on Spring Cloud error support] for more information.
+The binder can be configured to send producer exceptions to an error channel. See https://docs.spring.io/spring-cloud-stream/docs/current/reference/htmlsingle/#_spring_integration_error_channel_support[the section on Spring Cloud error channel support] for more information.
 
 The payload of the `ErrorMessage` for a send failure is an `AwsRequestFailureException` with properties:
 

--- a/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/KinesisMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/KinesisMessageChannelBinder.java
@@ -117,6 +117,7 @@ public class KinesisMessageChannelBinder extends
 			kinesisMessageHandler
 					.setPartitionKeyExpressionString("'partitionKey-' + headers." + BinderHeaders.PARTITION_HEADER);
 		}
+		kinesisMessageHandler.setFailureChannel(errorChannel);
 		kinesisMessageHandler.setBeanFactory(getBeanFactory());
 
 		return kinesisMessageHandler;

--- a/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/KinesisBinderTests.java
+++ b/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/KinesisBinderTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.stream.binder.kinesis;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -30,7 +29,6 @@ import com.amazonaws.services.kinesis.model.DescribeStreamRequest;
 import com.amazonaws.services.kinesis.model.DescribeStreamResult;
 import com.amazonaws.services.kinesis.model.PutRecordRequest;
 import com.amazonaws.services.kinesis.model.PutRecordResult;
-import com.amazonaws.services.kinesis.model.PutRecordsRequest;
 import com.amazonaws.services.kinesis.model.Shard;
 import com.amazonaws.services.kinesis.model.StreamDescription;
 import com.amazonaws.services.kinesis.model.StreamStatus;
@@ -40,8 +38,10 @@ import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import org.mockito.BDDMockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.cloud.stream.binder.BinderHeaders;
 import org.springframework.cloud.stream.binder.Binding;
@@ -71,7 +71,6 @@ import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 
@@ -286,7 +285,7 @@ public class KinesisBinderTests
 		final RuntimeException putRecordException = new RuntimeException("putRecordRequestEx");
 		final AtomicReference<Object> sent = new AtomicReference<>();
 		AmazonKinesisAsync amazonKinesisMock = mock(AmazonKinesisAsync.class);
-		given(amazonKinesisMock.putRecordAsync(any(PutRecordRequest.class), any(AsyncHandler.class)))
+		BDDMockito.given(amazonKinesisMock.putRecordAsync(any(PutRecordRequest.class), any(AsyncHandler.class)))
 				.willAnswer(new Answer<Future<PutRecordResult>>() {
 					@Override
 					public Future<PutRecordResult> answer(InvocationOnMock invocation) throws Throwable {

--- a/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/KinesisBinderTests.java
+++ b/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/KinesisBinderTests.java
@@ -16,14 +16,21 @@
 
 package org.springframework.cloud.stream.binder.kinesis;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
+import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.services.kinesis.AmazonKinesisAsync;
 import com.amazonaws.services.kinesis.model.DescribeStreamRequest;
 import com.amazonaws.services.kinesis.model.DescribeStreamResult;
+import com.amazonaws.services.kinesis.model.PutRecordRequest;
+import com.amazonaws.services.kinesis.model.PutRecordResult;
+import com.amazonaws.services.kinesis.model.PutRecordsRequest;
 import com.amazonaws.services.kinesis.model.Shard;
 import com.amazonaws.services.kinesis.model.StreamDescription;
 import com.amazonaws.services.kinesis.model.StreamStatus;
@@ -33,6 +40,9 @@ import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.cloud.stream.binder.BinderHeaders;
 import org.springframework.cloud.stream.binder.Binding;
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
@@ -40,11 +50,14 @@ import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.PartitionCapableBinderTests;
 import org.springframework.cloud.stream.binder.PartitionTestSupport;
 import org.springframework.cloud.stream.binder.Spy;
+import org.springframework.cloud.stream.binder.TestUtils;
 import org.springframework.cloud.stream.binder.kinesis.properties.KinesisBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.kinesis.properties.KinesisConsumerProperties;
 import org.springframework.cloud.stream.binder.kinesis.properties.KinesisProducerProperties;
+import org.springframework.context.ApplicationContext;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.aws.support.AwsRequestFailureException;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.FixedSubscriberChannel;
 import org.springframework.integration.channel.NullChannel;
@@ -53,9 +66,14 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.SubscribableChannel;
+import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Artem Bilan
@@ -258,6 +276,59 @@ public class KinesisBinderTests
 		input1Binding.unbind();
 		input2Binding.unbind();
 		outputBinding.unbind();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testProducerErrorChannel() throws Exception {
+		KinesisTestBinder binder = getBinder();
+
+		final RuntimeException putRecordException = new RuntimeException("putRecordRequestEx");
+		final AtomicReference<Object> sent = new AtomicReference<>();
+		AmazonKinesisAsync amazonKinesisMock = mock(AmazonKinesisAsync.class);
+		given(amazonKinesisMock.putRecordAsync(any(PutRecordRequest.class), any(AsyncHandler.class)))
+				.willAnswer(new Answer<Future<PutRecordResult>>() {
+					@Override
+					public Future<PutRecordResult> answer(InvocationOnMock invocation) throws Throwable {
+						PutRecordRequest request = invocation.getArgumentAt(0, PutRecordRequest.class);
+						sent.set(request.getData());
+						AsyncHandler<?, ?> handler = invocation.getArgumentAt(1, AsyncHandler.class);
+						handler.onError(putRecordException);
+						return mock(Future.class);
+					}
+				});
+
+		new DirectFieldAccessor(binder.getBinder()).setPropertyValue("amazonKinesis", amazonKinesisMock);
+
+		ExtendedProducerProperties<KinesisProducerProperties> producerProps = createProducerProperties();
+		producerProps.setErrorChannelEnabled(true);
+		DirectChannel moduleOutputChannel =
+				createBindableChannel("output", createProducerBindingProperties(producerProps));
+		Binding<MessageChannel> producerBinding = binder.bindProducer("ec.0", moduleOutputChannel, producerProps);
+
+		ApplicationContext applicationContext = TestUtils.getPropertyValue(binder.getBinder(),
+				"applicationContext", ApplicationContext.class);
+		SubscribableChannel ec = applicationContext.getBean("ec.0.errors", SubscribableChannel.class);
+		final AtomicReference<Message<?>> errorMessage = new AtomicReference<>();
+		final CountDownLatch latch = new CountDownLatch(1);
+		ec.subscribe(new MessageHandler() {
+			@Override
+			public void handleMessage(Message<?> message) throws MessagingException {
+				errorMessage.set(message);
+				latch.countDown();
+			}
+		});
+
+		String messagePayload = "oops";
+		moduleOutputChannel.send(new GenericMessage<>(messagePayload.getBytes()));
+
+		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(errorMessage.get()).isInstanceOf(ErrorMessage.class);
+		assertThat(errorMessage.get().getPayload()).isInstanceOf(AwsRequestFailureException.class);
+		AwsRequestFailureException exception = (AwsRequestFailureException) errorMessage.get().getPayload();
+		assertThat(exception.getCause()).isSameAs(putRecordException);
+		assertThat(((PutRecordRequest) exception.getRequest()).getData()).isSameAs(sent.get());
+		producerBinding.unbind();
 	}
 
 	@Test


### PR DESCRIPTION
Provides the error channel to the underlying `KinesisMessageHandler`.

@artembilan I was hoping to write a test for this behavior, but I don't see a good way to do it unless we expose setting of the `KinesisMessageHandler`'s `AsyncHandler` to the binder. Would it make sense to do so?

Resolves #10