### PR TITLE
Use default localstack ports

### DIFF
--- a/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/LocalDynamoDbResource.java
+++ b/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/LocalDynamoDbResource.java
@@ -34,7 +34,7 @@ import org.springframework.cloud.stream.test.junit.AbstractExternalResourceTestS
  */
 public final class LocalDynamoDbResource extends AbstractExternalResourceTestSupport<AmazonDynamoDBAsync> {
 
-	public static final int DEFAULT_PORT = 4568;
+	public static final int DEFAULT_PORT = 4569;
 
 	private final int port;
 

--- a/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/LocalKinesisResource.java
+++ b/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/LocalKinesisResource.java
@@ -39,7 +39,7 @@ import org.springframework.cloud.stream.test.junit.AbstractExternalResourceTestS
  */
 public class LocalKinesisResource extends AbstractExternalResourceTestSupport<AmazonKinesisAsync> {
 
-	public static final int DEFAULT_PORT = 4567;
+	public static final int DEFAULT_PORT = 4568;
 
 	private final int port;
 


### PR DESCRIPTION
According to https://github.com/localstack/localstack , Dynamodb listens at 4569 by default, and Kinesis listens at 4568 by default.

Aligning with that setup means that it is simpler to run these tests without having to tune the Localstack ports.