### PR TITLE
GH-107: Add ProducerMHandlerCustomizer support

### DIFF
--- a/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/config/KinesisBinderConfiguration.java
+++ b/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/config/KinesisBinderConfiguration.java
@@ -46,13 +46,16 @@ import org.springframework.cloud.stream.binder.kinesis.properties.KinesisBinderC
 import org.springframework.cloud.stream.binder.kinesis.properties.KinesisExtendedBindingProperties;
 import org.springframework.cloud.stream.binder.kinesis.provisioning.KinesisStreamProvisioner;
 import org.springframework.cloud.stream.binding.Bindable;
+import org.springframework.cloud.stream.config.ProducerMessageHandlerCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.integration.aws.lock.DynamoDbLockRegistry;
 import org.springframework.integration.aws.metadata.DynamoDbMetadataStore;
+import org.springframework.integration.aws.outbound.AbstractAwsMessageHandler;
 import org.springframework.integration.metadata.ConcurrentMetadataStore;
 import org.springframework.integration.support.locks.LockRegistry;
+import org.springframework.messaging.MessageHandler;
 
 /**
  * The auto-configuration for AWS components and Spring Cloud Stream Kinesis Binder.
@@ -211,7 +214,8 @@ public class KinesisBinderConfiguration {
 			@Autowired(required = false) AmazonDynamoDB dynamoDBClient,
 			@Autowired(required = false) AmazonDynamoDBStreams dynamoDBStreams,
 			@Autowired(required = false) AmazonCloudWatch cloudWatchClient,
-			@Autowired(required = false) KinesisProducerConfiguration kinesisProducerConfiguration) {
+			@Autowired(required = false) KinesisProducerConfiguration kinesisProducerConfiguration,
+			@Autowired(required = false) ProducerMessageHandlerCustomizer<? extends AbstractAwsMessageHandler<Void>> producerMessageHandlerCustomizer) {
 
 		KinesisMessageChannelBinder kinesisMessageChannelBinder =
 				new KinesisMessageChannelBinder(this.configurationProperties, provisioningProvider, amazonKinesis,
@@ -220,6 +224,7 @@ public class KinesisBinderConfiguration {
 		kinesisMessageChannelBinder.setLockRegistry(lockRegistry);
 		kinesisMessageChannelBinder.setExtendedBindingProperties(kinesisExtendedBindingProperties);
 		kinesisMessageChannelBinder.setKinesisProducerConfiguration(kinesisProducerConfiguration);
+		kinesisMessageChannelBinder.setProducerMessageHandlerCustomizer(producerMessageHandlerCustomizer);
 		return kinesisMessageChannelBinder;
 	}
 

--- a/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/KinesisBinderProcessorTests.java
+++ b/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/KinesisBinderProcessorTests.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.stream.binder.kinesis;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -25,12 +23,16 @@ import java.util.concurrent.TimeUnit;
 
 import cloud.localstack.docker.LocalstackDockerExtension;
 import cloud.localstack.docker.annotation.LocalstackDockerProperties;
+import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync;
 import com.amazonaws.services.kinesis.AmazonKinesisAsync;
+import com.amazonaws.services.kinesis.model.PutRecordRequest;
+import com.amazonaws.services.kinesis.model.PutRecordResult;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.extension.ExtendWith;
+import reactor.core.publisher.MonoProcessor;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,12 +66,7 @@ import org.springframework.messaging.support.GenericMessage;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.annotation.DirtiesContext;
 
-import com.amazonaws.handlers.AsyncHandler;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync;
-import com.amazonaws.services.kinesis.AmazonKinesisAsync;
-import com.amazonaws.services.kinesis.model.PutRecordRequest;
-import com.amazonaws.services.kinesis.model.PutRecordResult;
-import reactor.core.publisher.MonoProcessor;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * The tests for the processor SCSt application against local Kinesis and DynamoDB.
@@ -114,7 +111,7 @@ class KinesisBinderProcessorTests {
 	@Autowired
 	@Qualifier(Processor.INPUT + "." + CONSUMER_GROUP + ".errors")
 	private SubscribableChannel consumerErrorChannel;
-	
+
 	@Autowired
 	private ProcessorConfiguration config;
 


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-stream-binder-aws-kinesis/issues/107

To allow inject any custom properties into the created by the binder
`MessageHandlers`, provide support for a `ProducerMessageHandlerCustomizer`
injection into the `KinesisMessageChannelBinder`


Depends on https://github.com/spring-cloud/spring-cloud-stream/pull/1828