### PR TITLE
GH-119: Support listener mode for KCL Consumer

### DIFF
--- a/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/KinesisMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/KinesisMessageChannelBinder.java
@@ -89,6 +89,7 @@ import org.springframework.util.StringUtils;
  * @author Peter Oates
  * @author Artem Bilan
  * @author Arnaud Lecollaire
+ * @author Dirk Bonhomme
  */
 public class KinesisMessageChannelBinder extends
 		AbstractMessageChannelBinder<ExtendedConsumerProperties<KinesisConsumerProperties>,
@@ -366,6 +367,8 @@ public class KinesisMessageChannelBinder extends
 
 		adapter.setCheckpointMode(kinesisConsumerProperties.getCheckpointMode());
 		adapter.setCheckpointsInterval(kinesisConsumerProperties.getCheckpointInterval());
+
+		adapter.setListenerMode(kinesisConsumerProperties.getListenerMode());
 
 		if (properties.isUseNativeDecoding()) {
 			adapter.setConverter(null);


### PR DESCRIPTION
Fixes https://github.com/spring-cloud/spring-cloud-stream-binder-aws-kinesis/issues/119

Use Kinesis consumer listener mode from configuration when configuring KclMessageDrivenChannelAdapter