### PR TITLE
Speficy KinesisClientLibConfiguration by group name if available

### DIFF
--- a/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/KinesisMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/KinesisMessageChannelBinder.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
@@ -339,7 +340,7 @@ public class KinesisMessageChannelBinder extends
 
 		String stream = destination.getName();
 
-		KinesisClientLibConfiguration kinesisClientLibConfiguration = obtainKinesisClientLibConfiguration(stream);
+		KinesisClientLibConfiguration kinesisClientLibConfiguration = obtainKinesisClientLibConfiguration(stream, group);
 
 		KclMessageDrivenChannelAdapter adapter;
 
@@ -385,11 +386,17 @@ public class KinesisMessageChannelBinder extends
 		return adapter;
 	}
 
-	private KinesisClientLibConfiguration obtainKinesisClientLibConfiguration(String stream) {
-		return this.kinesisClientLibConfigurations.stream()
-				.filter(kinesisClientLibConfiguration -> stream.equals(kinesisClientLibConfiguration.getStreamName()))
-				.findFirst()
-				.orElse(null);
+	private KinesisClientLibConfiguration obtainKinesisClientLibConfiguration(String stream, String group) {
+		KinesisClientLibConfiguration candidate = null;
+		for (KinesisClientLibConfiguration conf : this.kinesisClientLibConfigurations) {
+			if (stream.equals(conf.getStreamName())) {
+				candidate = conf;
+				if (Objects.equals(group, conf.getApplicationName())) {
+					break;
+				}
+			}
+		}
+		return candidate;
 	}
 
 	private MessageProducer createKinesisConsumerEndpoint(ConsumerDestination destination, String group,


### PR DESCRIPTION
When multiple consumer groups exist on the same Spring application and these consumer listen to the same Kinesis stream, the previous logic selected  a wrong KinesisClientLibConfiguration even though KinesisClientLibConfiguration bean is provided for the consumer group.
Also the error occurred because of it.
```
Only one LastSubscriberMessageHandler is allowed
	at spring.cloud.stream@3.0.1.RELEASE/org.springframework.cloud.stream.binder.BinderErrorChannel.subscribe(BinderErrorChannel.java:44)
```