### PR TITLE
Fix cannot list shards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ dump.rdb
 coverage-error.log
 .apt_generated
 aws.credentials.properties
+/spring-cloud-stream-binder-kinesis/nbproject/
+nb-configuration.xml

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<amazon-kinesis-client.version>1.13.3</amazon-kinesis-client.version>
 		<amazon-kinesis-producer.version>0.14.1</amazon-kinesis-producer.version>
 		<dynamodb-stream.version>1.5.2</dynamodb-stream.version>
-		<localstack.version>0.1.22</localstack.version>
+		<localstack.version>0.2.2</localstack.version>
 	</properties>
 
 	<modules>
@@ -119,6 +119,7 @@
 					<artifactId>maven-surefire-plugin</artifactId>
 					<configuration>
 						<redirectTestOutputToFile>true</redirectTestOutputToFile>
+						<trimStackTrace>false</trimStackTrace>
 					</configuration>
 				</plugin>
 			</plugins>
@@ -247,5 +248,4 @@
 			</pluginRepositories>
 		</profile>
 	</profiles>
-
 </project>

--- a/spring-cloud-stream-binder-kinesis/pom.xml
+++ b/spring-cloud-stream-binder-kinesis/pom.xml
@@ -83,7 +83,5 @@
 			<artifactId>localstack-utils</artifactId>
 			<scope>test</scope>
 		</dependency>
-
 	</dependencies>
-
 </project>

--- a/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/KinesisMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/KinesisMessageChannelBinder.java
@@ -48,6 +48,7 @@ import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.ExtendedPropertiesBinder;
 import org.springframework.cloud.stream.binder.PartitionKeyExtractorStrategy;
+import org.springframework.cloud.stream.binder.kinesis.adapter.SpringDynamoDBAdapterClient;
 import org.springframework.cloud.stream.binder.kinesis.properties.KinesisBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.kinesis.properties.KinesisConsumerProperties;
 import org.springframework.cloud.stream.binder.kinesis.properties.KinesisExtendedBindingProperties;
@@ -146,7 +147,7 @@ public class KinesisMessageChannelBinder extends
 		this.awsCredentialsProvider = awsCredentialsProvider;
 
 		if (dynamoDBStreams != null) {
-			this.dynamoDBStreamsAdapter = new AmazonDynamoDBStreamsAdapterClient(dynamoDBStreams);
+			this.dynamoDBStreamsAdapter = new SpringDynamoDBAdapterClient(dynamoDBStreams);
 		}
 		else {
 			this.dynamoDBStreamsAdapter = null;

--- a/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/adapter/SpringDynamoDBAdapterClient.java
+++ b/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/adapter/SpringDynamoDBAdapterClient.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.kinesis.adapter;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBStreams;
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
+import com.amazonaws.services.dynamodbv2.streamsadapter.AmazonDynamoDBStreamsAdapterClient;
+import com.amazonaws.services.kinesis.model.DescribeStreamRequest;
+import com.amazonaws.services.kinesis.model.InvalidArgumentException;
+import com.amazonaws.services.kinesis.model.ListShardsRequest;
+import com.amazonaws.services.kinesis.model.ListShardsResult;
+import com.amazonaws.services.kinesis.model.ResourceNotFoundException;
+import com.amazonaws.services.kinesis.model.StreamDescription;
+
+/**
+ * This is Spring Cloud DynamoDB Adapter to be able to support {@code ListShards} operations.
+ *
+ * @author Asiel Caballero
+ * @since 2.0.3
+ * @see <a href="https://docs.aws.amazon.com/kinesis/latest/APIReference/API_ListShards.html">ListShards</a>
+ */
+public class SpringDynamoDBAdapterClient extends AmazonDynamoDBStreamsAdapterClient {
+
+	private static final String SEPARATOR = "!!##%%";
+
+	public SpringDynamoDBAdapterClient(AmazonDynamoDBStreams amazonDynamoDBStreams) {
+		super(amazonDynamoDBStreams);
+	}
+
+	/**
+	 * List shards for a DynamoDB Stream using its {@code DescribeStream} API, as they don't support
+	 * {@code ListShards} operations. Returns the result adapted to use the AmazonKinesis model.
+	 * @param request Container for the necessary parameters to execute the ListShards service method
+	 * @return The response from the DescribeStream service method, adapted for use with the AmazonKinesis model
+	 */
+	@Override
+	public ListShardsResult listShards(ListShardsRequest request) {
+		try {
+			if (request.getNextToken() != null && request.getStreamName() != null) {
+				throw new InvalidArgumentException("NextToken and StreamName cannot be provided together.");
+			}
+
+			String streamName = request.getStreamName();
+			String exclusiveStartShardId = request.getExclusiveStartShardId();
+
+			if (request.getNextToken() != null) {
+				String[] split = request.getNextToken().split(SEPARATOR);
+
+				if (split.length != 2) {
+					throw new InvalidArgumentException("Invalid ShardIterator");
+				}
+
+				streamName = split[0];
+				exclusiveStartShardId = split[1];
+			}
+
+			DescribeStreamRequest dsr = new DescribeStreamRequest()
+					.withStreamName(streamName)
+					.withExclusiveStartShardId(exclusiveStartShardId)
+					.withLimit(request.getMaxResults());
+			StreamDescription streamDescription = describeStream(dsr).getStreamDescription();
+
+			ListShardsResult result = new ListShardsResult()
+					.withShards(streamDescription.getShards());
+
+			if (streamDescription.getHasMoreShards()) {
+				result.withNextToken(buildFakeNextToken(streamName,
+						streamDescription.getShards().get(streamDescription.getShards().size() - 1).getShardId()));
+			}
+
+			return result;
+		}
+		catch (AmazonDynamoDBException ex) {
+			ResourceNotFoundException retrownEx = new ResourceNotFoundException(ex.getMessage());
+			retrownEx.setStackTrace(ex.getStackTrace());
+			throw retrownEx;
+		}
+	}
+
+	private String buildFakeNextToken(String streamName, String lastShard) {
+		return lastShard != null ? streamName + SEPARATOR + lastShard : null;
+	}
+}

--- a/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/ExtendedDockerTestUtils.java
+++ b/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/ExtendedDockerTestUtils.java
@@ -18,8 +18,9 @@ package org.springframework.cloud.stream.binder.kinesis;
 
 import java.util.function.Supplier;
 
-import cloud.localstack.TestUtils;
-import cloud.localstack.docker.LocalstackDocker;
+import cloud.localstack.Constants;
+import cloud.localstack.Localstack;
+import cloud.localstack.awssdkv1.TestUtils;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.client.builder.AwsAsyncClientBuilder;
 import com.amazonaws.client.builder.AwsClientBuilder;
@@ -35,11 +36,13 @@ import com.amazonaws.services.kinesis.AmazonKinesisAsyncClientBuilder;
  */
 public final class ExtendedDockerTestUtils {
 
+	private ExtendedDockerTestUtils() { }
+
 	public static AmazonKinesisAsync getClientKinesisAsync() {
 		AmazonKinesisAsyncClientBuilder amazonKinesisAsyncClientBuilder =
 				AmazonKinesisAsyncClientBuilder.standard()
 						.withEndpointConfiguration(
-								createEndpointConfiguration(LocalstackDocker.INSTANCE::getEndpointKinesis));
+								createEndpointConfiguration(Localstack.INSTANCE::getEndpointKinesis));
 		return applyConfigurationAndBuild(amazonKinesisAsyncClientBuilder);
 	}
 
@@ -47,12 +50,12 @@ public final class ExtendedDockerTestUtils {
 		AmazonDynamoDBAsyncClientBuilder dynamoDBAsyncClientBuilder =
 				AmazonDynamoDBAsyncClientBuilder.standard()
 						.withEndpointConfiguration(
-								createEndpointConfiguration(LocalstackDocker.INSTANCE::getEndpointDynamoDB));
+								createEndpointConfiguration(Localstack.INSTANCE::getEndpointDynamoDB));
 		return applyConfigurationAndBuild(dynamoDBAsyncClientBuilder);
 	}
 
 	private static AwsClientBuilder.EndpointConfiguration createEndpointConfiguration(Supplier<String> supplier) {
-		return new AwsClientBuilder.EndpointConfiguration(supplier.get(), TestUtils.DEFAULT_REGION);
+		return new AwsClientBuilder.EndpointConfiguration(supplier.get(), Constants.DEFAULT_REGION);
 	}
 
 	private static <T, C extends AwsAsyncClientBuilder<C, T>> T applyConfigurationAndBuild(C builder) {
@@ -60,8 +63,4 @@ public final class ExtendedDockerTestUtils {
 				.withClientConfiguration(new ClientConfiguration().withMaxErrorRetry(0).withConnectionTimeout(1000))
 				.build();
 	}
-
-	private ExtendedDockerTestUtils() {
-	}
-
 }

--- a/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/KinesisBinderTests.java
+++ b/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/KinesisBinderTests.java
@@ -25,7 +25,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import cloud.localstack.docker.LocalstackDockerTestRunner;
+import cloud.localstack.LocalstackTestRunner;
 import cloud.localstack.docker.annotation.LocalstackDockerProperties;
 import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync;
@@ -91,7 +91,7 @@ import static org.mockito.Mockito.mock;
  * @author Arnaud Lecollaire
  */
 @Ignore("Doesn't work on Jenkins")
-@RunWith(LocalstackDockerTestRunner.class)
+@RunWith(LocalstackTestRunner.class)
 @LocalstackDockerProperties(randomizePorts = true,
 		hostNameResolver = EnvironmentHostNameResolver.class,
 		services = { "kinesis", "dynamodb"})

--- a/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/adapter/SpringDynamoDBAdapterClientTests.java
+++ b/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/adapter/SpringDynamoDBAdapterClientTests.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2017-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.stream.binder.kinesis.adapter;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import cloud.localstack.Constants;
+import com.amazonaws.services.dynamodbv2.AbstractAmazonDynamoDBStreams;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBStreams;
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
+import com.amazonaws.services.dynamodbv2.model.DescribeStreamRequest;
+import com.amazonaws.services.dynamodbv2.model.DescribeStreamResult;
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
+import com.amazonaws.services.dynamodbv2.model.KeyType;
+import com.amazonaws.services.dynamodbv2.model.SequenceNumberRange;
+import com.amazonaws.services.dynamodbv2.model.Shard;
+import com.amazonaws.services.dynamodbv2.model.StreamDescription;
+import com.amazonaws.services.dynamodbv2.model.StreamStatus;
+import com.amazonaws.services.dynamodbv2.model.StreamViewType;
+import com.amazonaws.services.kinesis.model.InvalidArgumentException;
+import com.amazonaws.services.kinesis.model.ListShardsRequest;
+import com.amazonaws.services.kinesis.model.ListShardsResult;
+import com.amazonaws.services.kinesis.model.ResourceNotFoundException;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SpringDynamoDBAdapterClientTests {
+	private final AmazonDynamoDBStreams amazonDynamoDBStreams = new InMemoryAmazonDynamoDBStreams();
+	private final SpringDynamoDBAdapterClient springDynamoDBAdapterClient = new SpringDynamoDBAdapterClient(amazonDynamoDBStreams);
+
+	@Test(expected = ResourceNotFoundException.class)
+	public void listShardsForNotFoundStream() {
+		springDynamoDBAdapterClient.listShards(new ListShardsRequest()
+				.withStreamName("not-found"));
+	}
+
+	@Test(expected = InvalidArgumentException.class)
+	public void listShardsWithInvalidToken() {
+		springDynamoDBAdapterClient.listShards(new ListShardsRequest()
+				.withNextToken("invalid-token"));
+	}
+
+	@Test(expected = InvalidArgumentException.class)
+	public void listShardsWithTokenAndStreamName() {
+		springDynamoDBAdapterClient.listShards(new ListShardsRequest()
+				.withStreamName(InMemoryAmazonDynamoDBStreams.STREAM_ARN)
+				.withNextToken("valid!!##%%token"));
+	}
+
+	@Test
+	public void listShardsNoPagination() {
+		ListShardsResult listShards = springDynamoDBAdapterClient.listShards(new ListShardsRequest()
+				.withStreamName(InMemoryAmazonDynamoDBStreams.STREAM_ARN));
+
+		assertThat(listShards.getNextToken()).isNull();
+		assertThat(listShards.getShards().size()).isEqualTo(InMemoryAmazonDynamoDBStreams.SHARDS.size());
+	}
+
+	@Test
+	public void listShardWithTokenPagination() {
+		int maxResults = (InMemoryAmazonDynamoDBStreams.SHARDS.size() / 2)
+				+ (InMemoryAmazonDynamoDBStreams.SHARDS.size() % 2);
+		ListShardsResult listShards = springDynamoDBAdapterClient.listShards(new ListShardsRequest()
+				.withStreamName(InMemoryAmazonDynamoDBStreams.STREAM_ARN)
+				.withMaxResults(maxResults));
+
+		assertThat(listShards.getNextToken()).isNotNull();
+		assertThat(listShards.getShards().size()).isEqualTo(maxResults);
+
+		listShards = springDynamoDBAdapterClient.listShards(new ListShardsRequest()
+				.withNextToken(listShards.getNextToken()));
+
+		assertThat(listShards.getNextToken()).isNull();
+		assertThat(listShards.getShards().size()).isEqualTo(InMemoryAmazonDynamoDBStreams.SHARDS.size() - maxResults);
+	}
+
+	@Test
+	public void listShardsWithShardIdPagination() {
+		ListShardsResult listShards = springDynamoDBAdapterClient.listShards(new ListShardsRequest()
+				.withStreamName(InMemoryAmazonDynamoDBStreams.STREAM_ARN)
+				.withExclusiveStartShardId(InMemoryAmazonDynamoDBStreams.SHARDS.get(2).getShardId())
+				.withMaxResults(1));
+
+		assertThat(listShards.getNextToken()).isNotNull();
+		assertThat(listShards.getShards().size()).isEqualTo(1);
+		assertThat(listShards.getShards().get(0).getShardId())
+				.isEqualTo(InMemoryAmazonDynamoDBStreams.SHARDS.get(3).getShardId());
+	}
+
+
+	private static class InMemoryAmazonDynamoDBStreams extends AbstractAmazonDynamoDBStreams {
+		private static final String TABLE_NAME = "test-streams";
+		private static final String STREAM_LABEL = "2020-10-21T11:49:13.355";
+		private static final String STREAM_ARN = String
+				.format("arn:aws:dynamodb:%s:%s:table/%s/stream/%s",
+						Constants.DEFAULT_REGION, Constants.DEFAULT_AWS_ACCOUNT_ID, TABLE_NAME, STREAM_LABEL);
+		private static final List<Shard> SHARDS = Arrays.asList(
+				buildShard("shardId-00000001603195033866-c5d0c2b1", "51100000000002515059163", "51300000000002521847055"),
+				buildShard("shardId-00000001603208699318-b15c42af", "804300000000026046960744", "804300000000026046960744")
+						.withParentShardId("shardId-00000001603195033866-c5d0c2b1"),
+				buildShard("shardId-00000001603223404428-90b80e6c", "1613900000000033324335703", "1613900000000033324335703")
+						.withParentShardId("shardId-00000001603208699318-b15c42af"),
+				buildShard("shardId-00000001603237029376-bd9c40dd", "2364600000000001701561758", "2364600000000001701561758")
+						.withParentShardId("shardId-00000001603223404428-90b80e6c"),
+				buildShard("shardId-00000001603249855034-b917a47f", "3071400000000035046301998", "3071400000000035046301998")
+						.withParentShardId("shardId-00000001603237029376-bd9c40dd"));
+
+		private final StreamDescription streamDescription = new StreamDescription()
+				.withStreamArn(STREAM_ARN)
+				.withStreamLabel(STREAM_LABEL)
+				.withStreamViewType(StreamViewType.KEYS_ONLY)
+				.withCreationRequestDateTime(new Date())
+				.withTableName(TABLE_NAME)
+				.withKeySchema(new KeySchemaElement("name", KeyType.HASH))
+				.withStreamStatus(StreamStatus.ENABLED);
+
+		private static Shard buildShard(String parentShardIdString, String startingSequenceNumber, String endingSequenceNumber) {
+			return new Shard()
+				.withShardId(parentShardIdString)
+				.withSequenceNumberRange(new SequenceNumberRange()
+						.withStartingSequenceNumber(startingSequenceNumber)
+						.withEndingSequenceNumber(endingSequenceNumber));
+		}
+
+		@Override
+		public DescribeStreamResult describeStream(DescribeStreamRequest request) {
+			// Invalid StreamArn (Service: AmazonDynamoDBStreams; Status Code: 400; Error Code: ValidationException; Request ID: <Request ID>; Proxy: null)
+			if (!STREAM_ARN.equals(request.getStreamArn())) {
+				throw new AmazonDynamoDBException("Invalid StreamArn");
+			}
+
+			int limit = request.getLimit() != null ? request.getLimit() : 100;
+
+			int shardIndex = request.getExclusiveStartShardId() != null
+					? findShardIndex(request.getExclusiveStartShardId())
+					: 0;
+			int lastShardIndex = Math.min(shardIndex + limit, SHARDS.size());
+			streamDescription.setShards(SHARDS.subList(shardIndex, lastShardIndex));
+			streamDescription.setLastEvaluatedShardId(lastShardIndex != SHARDS.size() ? SHARDS.get(lastShardIndex).getShardId() : null);
+
+			DescribeStreamResult result = new DescribeStreamResult()
+					.withStreamDescription(streamDescription);
+			return result;
+		}
+
+		private int findShardIndex(String shardId) {
+			int i = 0;
+			// checkstyle forced this way of writing it
+			for (; i < SHARDS.size() && !SHARDS.get(i).getShardId().equals(shardId);) {
+				i++;
+			}
+
+			if (i + 1 >= SHARDS.size()) {
+				throw new RuntimeException("ShardId not found");
+			}
+
+			return i + 1;
+		}
+	}
+}


### PR DESCRIPTION
Adds custom adapater for DynamoDB Stream to the AmazonKinesis model to
support `ListShards` operations. It uses `DescribeStream` API under the
hood as `ListShards` is not available for DynamoStreams.

Bumps LocalStack version from `0.1.22` to `0.2.2`.

Resolves: https://github.com/spring-projects/spring-integration-aws/issues/181