### PR TITLE
Add support for on-demand Metadata and LockRegistry tables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<java.version>1.8</java.version>
 		<spring-cloud-stream.version>3.0.8.RELEASE</spring-cloud-stream.version>
 		<spring-cloud-aws.version>2.2.4.RELEASE</spring-cloud-aws.version>
-		<spring-integration-aws.version>2.3.4.RELEASE</spring-integration-aws.version>
+		<spring-integration-aws.version>2.3.5.BUILD-SNAPSHOT</spring-integration-aws.version>
 		<dynamodb-lock-client.version>1.1.0</dynamodb-lock-client.version>
 		<amazon-kinesis-client.version>1.14.0</amazon-kinesis-client.version>
 		<amazon-kinesis-producer.version>0.14.1</amazon-kinesis-producer.version>

--- a/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
@@ -138,14 +138,18 @@ createRetries::
     The amount of times the consumer will poll DynamoDB while waiting for the checkpoint table to be created
 +
 Default: `25`
+billingMode::
+    The Billing Mode of the DynamoDB table. See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.OnDemand[DynamoDB On-Demand Mode]. Possible values are `provisioned` and `payPerRequest`. If left empty or set to `payPerRequest` both `readCapacity` and `writeCapacity` are ignored
++
+Default: `payPerRequest`
 readCapacity::
 	The Read capacity of the DynamoDb table.
-See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ProvisionedThroughput.html[Kinesis Provisioned Throughput]
+See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.ProvisionedThroughput.Manual[DynamoDB Provisioned Throughput]. This property is used only when `billingMode` is set to `provisioned`
 +
 Default: `1`
 writeCapacity::
 	The write capacity of the DynamoDb table.
-See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ProvisionedThroughput.html[Kinesis Provisioned Throughput]
+See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.ProvisionedThroughput.Manual[DynamoDB Provisioned Throughput]. This property is used only when `billingMode` is set to `provisioned`
 +
 Default: `1`
 timeToLive::
@@ -161,17 +165,22 @@ This is implemented using https://github.com/spring-projects/spring-integration-
 DynamoDB `LockRegistry` properties are prefixed with `spring.cloud.stream.kinesis.binder.locks.`
 
 table::
-	The name to give the DynamoDb table
+	The name to give the DynamoDB table
 +
 Default: `SpringIntegrationLockRegistry`
+billingMode::
+    The Billing Mode of the DynamoDB table. See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.OnDemand[DynamoDB On-Demand Mode]. Possible values are `provisioned` and `payPerRequest`. If left empty or set to `payPerRequest` both `readCapacity` and `writeCapacity` are ignored
++
+Default: `payPerRequest`
 readCapacity::
-	The Read capacity of the DynamoDb table.
-See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ProvisionedThroughput.html[Kinesis Provisioned Throughput]
+	The Read capacity of the DynamoDB table.
+See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.ProvisionedThroughput.Manual[DynamoDB Provisioned Throughput]. This property is used only when `billingMode` is set to `provisioned`
 +
 Default: `1`
 writeCapacity::
 	The write capacity of the DynamoDb table.
-See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ProvisionedThroughput.html[Kinesis Provisioned Throughput]
+See https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.ProvisionedThroughput.Manual[DynamoDB Provisioned Throughput]. This property is used only when `billingMode` is set to `provisioned`
++
 Default: `1`
 leaseDuration::
 	The length of time that the lease for the lock will be granted for.

--- a/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/config/KinesisBinderConfiguration.java
+++ b/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/config/KinesisBinderConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ import org.springframework.integration.support.locks.LockRegistry;
  * @author Peter Oates
  * @author Artem Bilan
  * @author Arnaud Lecollaire
+ * @author Asiel Caballero
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnMissingBean(Binder.class)
@@ -143,6 +144,7 @@ public class KinesisBinderConfiguration {
 			dynamoDbLockRegistry.setPartitionKey(locks.getPartitionKey());
 			dynamoDbLockRegistry.setSortKeyName(locks.getSortKeyName());
 			dynamoDbLockRegistry.setSortKey(locks.getSortKey());
+			dynamoDbLockRegistry.setBillingMode(locks.getBillingMode());
 			dynamoDbLockRegistry.setReadCapacity(locks.getReadCapacity());
 			dynamoDbLockRegistry.setWriteCapacity(locks.getWriteCapacity());
 			return dynamoDbLockRegistry;
@@ -161,6 +163,7 @@ public class KinesisBinderConfiguration {
 		if (dynamoDB != null) {
 			KinesisBinderConfigurationProperties.Checkpoint checkpoint = this.configurationProperties.getCheckpoint();
 			DynamoDbMetadataStore kinesisCheckpointStore = new DynamoDbMetadataStore(dynamoDB, checkpoint.getTable());
+			kinesisCheckpointStore.setBillingMode(checkpoint.getBillingMode());
 			kinesisCheckpointStore.setReadCapacity(checkpoint.getReadCapacity());
 			kinesisCheckpointStore.setWriteCapacity(checkpoint.getWriteCapacity());
 			kinesisCheckpointStore.setCreateTableDelay(checkpoint.getCreateDelay());

--- a/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/KinesisBinderConfigurationProperties.java
+++ b/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/KinesisBinderConfigurationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.binder.kinesis.properties;
 
+import com.amazonaws.services.dynamodbv2.model.BillingMode;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.integration.aws.lock.DynamoDbLockRegistry;
 import org.springframework.integration.aws.metadata.DynamoDbMetadataStore;
@@ -28,6 +30,7 @@ import org.springframework.integration.aws.metadata.DynamoDbMetadataStore;
  * @author Jacob Severson
  * @author Sergiu Pantiru
  * @author Arnaud Lecollaire
+ * @author Asiel Caballero
  */
 @ConfigurationProperties(prefix = "spring.cloud.stream.kinesis.binder")
 public class KinesisBinderConfigurationProperties {
@@ -124,6 +127,8 @@ public class KinesisBinderConfigurationProperties {
 
 		private String table = DynamoDbMetadataStore.DEFAULT_TABLE_NAME;
 
+		private BillingMode billingMode = BillingMode.PAY_PER_REQUEST;
+
 		private long readCapacity = 1L;
 
 		private long writeCapacity = 1L;
@@ -140,6 +145,14 @@ public class KinesisBinderConfigurationProperties {
 
 		public void setTable(String table) {
 			this.table = table;
+		}
+
+		public BillingMode getBillingMode() {
+			return billingMode;
+		}
+
+		public void setBillingMode(BillingMode billingMode) {
+			this.billingMode = billingMode;
 		}
 
 		public long getReadCapacity() {
@@ -191,6 +204,8 @@ public class KinesisBinderConfigurationProperties {
 
 		private String table = DynamoDbLockRegistry.DEFAULT_TABLE_NAME;
 
+		private BillingMode billingMode = BillingMode.PAY_PER_REQUEST;
+
 		private long readCapacity = 1L;
 
 		private long writeCapacity = 1L;
@@ -213,6 +228,14 @@ public class KinesisBinderConfigurationProperties {
 
 		public void setTable(String table) {
 			this.table = table;
+		}
+
+		public BillingMode getBillingMode() {
+			return billingMode;
+		}
+
+		public void setBillingMode(BillingMode billingMode) {
+			this.billingMode = billingMode;
 		}
 
 		public long getReadCapacity() {
@@ -278,7 +301,5 @@ public class KinesisBinderConfigurationProperties {
 		public void setHeartbeatPeriod(long heartbeatPeriod) {
 			this.heartbeatPeriod = heartbeatPeriod;
 		}
-
 	}
-
 }


### PR DESCRIPTION
Adds the option to create MetadataStore and LockRegistry tables as
On-Demand (Pay Per Request). It allows production ready tables that will
hardly suffer from provisioning issue during production like loads.

Resolves: https://github.com/spring-cloud/spring-cloud-stream-binder-aws-kinesis/issues/145