### PR TITLE
build: Update dependency for amazon-kinesis-producer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<spring-integration-aws.version>2.5.1</spring-integration-aws.version>
 		<dynamodb-lock-client.version>1.1.0</dynamodb-lock-client.version>
 		<amazon-kinesis-client.version>1.14.3</amazon-kinesis-client.version>
-		<amazon-kinesis-producer.version>0.14.6</amazon-kinesis-producer.version>
+		<amazon-kinesis-producer.version>0.14.12</amazon-kinesis-producer.version>
 		<dynamodb-stream.version>1.5.2</dynamodb-stream.version>
 		<localstack.version>0.2.11</localstack.version>
 	</properties>


### PR DESCRIPTION
Upgrading version of amazon-kinesis-producer dependency to  0.14.12.  This is intended to resolve vulnerabilities in the downstream dependency `commons-compress` v 1.19 listed [here](https://mvnrepository.com/artifact/org.apache.commons/commons-compress/1.19)
 [CVE-2021-36090](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-36090)
[CVE-2021-35517](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-35517)
[CVE-2021-35516](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-35516)
[CVE-2021-35515](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-35515)