### PR TITLE
Fix AWS Policies required by Spring Cloud Stream

### DIFF
--- a/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
@@ -365,7 +365,8 @@ Here are the policies statements that your application role need:
             "dynamodb:GetItem",
             "dynamodb:Scan",
             "dynamodb:Query",
-            "dynamodb:UpdateItem"
+            "dynamodb:UpdateItem",
+	    "dynamodb:DescribeTable"
           ],
           "Resource": [
             "arn:aws:dynamodb:<region>:<account>:table/<name-of-metadata-table>",


### PR DESCRIPTION
Spring Cloud Stream Binder Kinesis requires dynamodb:DescribeTable policy for SpringIntegrationMetadataStore table. Without the DescribeTable policy granted for the user Spring won't be able to instantiate the bean `kinesisCheckpointStore` required by the bean `kinesisMessageChannelBinder`.