### PR TITLE
Add necessary access: kinesis:ListShards and encrypting and decrypting Kinesis messages

### DIFF
--- a/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
@@ -346,6 +346,16 @@ Here are the policies statements that your application role need:
             "arn:aws:dynamodb:<region>:<account>:table/<name-of-metadata-table>",
             "arn:aws:dynamodb:<region>:<account>:table/<name-of-lock-table>"
           ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kms:GenerateDataKey",
+		"kms:Decrypt"
+            ],
+            "Resource": [
+                "arn:aws:kms:<region>:<account>:key/<kms-key-uuid>"
+            ]
         }
     ]
 }

--- a/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
@@ -346,16 +346,6 @@ Here are the policies statements that your application role need:
             "arn:aws:dynamodb:<region>:<account>:table/<name-of-metadata-table>",
             "arn:aws:dynamodb:<region>:<account>:table/<name-of-lock-table>"
           ]
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "kms:GenerateDataKey",
-		"kms:Decrypt"
-            ],
-            "Resource": [
-                "arn:aws:kms:<region>:<account>:key/<kms-key-uuid>"
-            ]
         }
     ]
 }
@@ -382,6 +372,26 @@ If you're going to allow spring-cloud-stream-binder-kinesis to create the resour
             "Resource": [
                 "arn:aws:dynamodb:<region>:<account>:table/<table_name>",
                 "arn:aws:kinesis:<region>:<account>:stream/<stream_name>"
+            ]
+        }
+    ]
+}
+----
+
+If [Server-Side Encryption](https://docs.aws.amazon.com/streams/latest/dev/what-is-sse.html) is enabled, you'll need the following set of policies to encrypt and decrypt Kinesis messages. 
+[source,json]
+----
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "kms:GenerateDataKey",
+		"kms:Decrypt"
+            ],
+            "Resource": [
+                "arn:aws:kms:<region>:<account>:key/<kms-key-uuid>"
             ]
         }
     ]

--- a/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
@@ -310,7 +310,8 @@ Here are the policies statements that your application role need:
         {
             "Effect": "Allow",
             "Action": [
-                "kinesis:SubscribeToShard",
+                "kinesis:ListShards",
+		"kinesis:SubscribeToShard",
                 "kinesis:DescribeStreamSummary",
                 "kinesis:DescribeStreamConsumer",
                 "kinesis:GetShardIterator",


### PR DESCRIPTION
1. `kinesis:ListShards` is necessary for consumer.

```
2023-03-31 02:47:54.944+0000 ERROR 9797 --- [   scheduling-1]  org.springframework.cloud.stream.binding.BindingService.rescheduleConsumerBinding : Failed to create consumer binding; retrying in 30 seconds

org.springframework.cloud.stream.binder.BinderException: Exception thrown while starting consumer: 
	at org.springframework.cloud.stream.binder.AbstractMessageChannelBinder.doBindConsumer(AbstractMessageChannelBinder.java:487)
	at org.springframework.cloud.stream.binder.AbstractMessageChannelBinder.doBindConsumer(AbstractMessageChannelBinder.java:98)
	at org.springframework.cloud.stream.binder.AbstractBinder.bindConsumer(AbstractBinder.java:143)
	at org.springframework.cloud.stream.binding.BindingService.lambda$rescheduleConsumerBinding$1(BindingService.java:209)
	at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: com.amazonaws.services.kinesis.model.AmazonKinesisException: User: <user> is not authorized to perform: kinesis:ListShards on resource: <kinesis-resource> because no identity-based policy allows the kinesis:ListShards action (Service: AmazonKinesis; Status Code: 400; Error Code: AccessDeniedException; Request ID: <uuid>; Proxy: null)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1819)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleServiceErrorResponse(AmazonHttpClient.java:1403)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1372)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1145)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:802)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:770)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:744)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:704)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:686)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:550)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:530)
	at com.amazonaws.services.kinesis.AmazonKinesisClient.doInvoke(AmazonKinesisClient.java:2893)
	at com.amazonaws.services.kinesis.AmazonKinesisClient.invoke(AmazonKinesisClient.java:2860)
	at com.amazonaws.services.kinesis.AmazonKinesisClient.invoke(AmazonKinesisClient.java:2849)
	at com.amazonaws.services.kinesis.AmazonKinesisClient.executeListShards(AmazonKinesisClient.java:1590)
	at com.amazonaws.services.kinesis.AmazonKinesisClient.listShards(AmazonKinesisClient.java:1559)
	at org.springframework.cloud.stream.binder.kinesis.provisioning.KinesisStreamProvisioner.getShardList(KinesisStreamProvisioner.java:141)
	at org.springframework.cloud.stream.binder.kinesis.provisioning.KinesisStreamProvisioner.getShardList(KinesisStreamProvisioner.java:122)
	at org.springframework.cloud.stream.binder.kinesis.provisioning.KinesisStreamProvisioner.createOrUpdate(KinesisStreamProvisioner.java:167)
	at org.springframework.cloud.stream.binder.kinesis.provisioning.KinesisStreamProvisioner.provisionConsumerDestination(KinesisStreamProvisioner.java:118)
	at org.springframework.cloud.stream.binder.kinesis.provisioning.KinesisStreamProvisioner.provisionConsumerDestination(KinesisStreamProvisioner.java:59)
	at org.springframework.cloud.stream.binder.AbstractMessageChannelBinder.doBindConsumer(AbstractMessageChannelBinder.java:428)
	... 10 common frames omitted
```

2. `kms:GenerateDataKey`(for producer) and `kms:Decrypt`(for consumer) should be allowed on the corresponding KMS key as well.

```
Got an exception com.amazonaws.services.kinesis.model.KMSAccessDeniedException:
User *:* is not authorized to decrypt records in stream *
(Service: AmazonKinesis; Status Code: 400; Error Code: KMSAccessDeniedException; Request ID: *; Proxy: null)
during [ShardConsumer{shardOffset=KinesisShardOffset{iteratorType=TRIM_HORIZON, sequenceNumber='null',
timestamp=null, stream='service-platform-kinesis-demo', shard='shardId-000000000000', reset=false},
state=CONSUME}] task invocation.
```

Feel free to update the code.