### PR TITLE
feat  : update localstack provisioning script

### DIFF
--- a/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
+++ b/spring-cloud-stream-binder-kinesis-docs/src/main/asciidoc/overview.adoc
@@ -458,15 +458,15 @@ awslocal kinesis create-stream --stream-name my-test-stream --shard-count 1
 
 awslocal dynamodb create-table \
 --table-name spring-stream-lock-registry \
---attribute-definitions AttributeName=lockKey,AttributeType=S AttributeName=sortKey,AttributeType=S \
---key-schema AttributeName=lockKey,KeyType=HASH AttributeName=sortKey,KeyType=RANGE \
+--attribute-definitions AttributeName=lockKey,AttributeType=S \
+--key-schema AttributeName=lockKey,KeyType=HASH \
 --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5 \
 --tags Key=Owner,Value=localstack
 
 awslocal dynamodb create-table \
 --table-name spring-stream-metadata \
---attribute-definitions AttributeName=KEY,AttributeType=S \
---key-schema AttributeName=KEY,KeyType=HASH \
+--attribute-definitions AttributeName=metadataKey,AttributeType=S \
+--key-schema AttributeName=metadataKey,KeyType=HASH \
 --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5 \
 --tags Key=Owner,Value=localstack
 


### PR DESCRIPTION
Currently with sortkey it is throwing validation error, hence removed from `spring-stream-lock-registry` table and key name under should be `spring-stream-metadata` metadataKey

If we let spring create the dynamo db tables then it will not use sortKey, Hence matching it here