### PR TITLE
KinesisStreamProvisioner is overwriting headerMode property

### DIFF
--- a/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/KinesisMessageChannelBinder.java
+++ b/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/KinesisMessageChannelBinder.java
@@ -226,11 +226,11 @@ public class KinesisMessageChannelBinder extends
 		AbstractAwsMessageHandler<?> messageHandler;
 		if (this.configurationProperties.isKplKclEnabled()) {
 			messageHandler = createKplMessageHandler(destination, partitionKeyExpression,
-					producerProperties.getExtension().isEmbedHeaders());
+					producerProperties.getExtension().isEmbedHeaders() && !producerProperties.isUseNativeEncoding());
 		}
 		else {
 			messageHandler = createKinesisMessageHandler(destination, partitionKeyExpression,
-					producerProperties.getExtension().isEmbedHeaders());
+					producerProperties.getExtension().isEmbedHeaders() && !producerProperties.isUseNativeEncoding());
 		}
 		messageHandler.setAsync(!producerProperties.getExtension().isSync());
 		messageHandler.setSendTimeout(producerProperties.getExtension().getSendTimeout());
@@ -424,7 +424,7 @@ public class KinesisMessageChannelBinder extends
 		adapter.setPollingMaxRecords(kinesisConsumerProperties.getPollingMaxRecords());
 		adapter.setPollingIdleTime(kinesisConsumerProperties.getPollingIdleTime());
 		adapter.setGracefulShutdownTimeout(kinesisConsumerProperties.getGracefulShutdownTimeout());
-		if (properties.getExtension().isEmbedHeaders()) {
+		if (properties.getExtension().isEmbedHeaders() && !properties.isUseNativeDecoding()) {
 			adapter.setEmbeddedHeadersMapper(this.embeddedHeadersMapper);
 		}
 
@@ -523,7 +523,7 @@ public class KinesisMessageChannelBinder extends
 						: KinesisShardOffset.trimHorizon());
 
 		adapter.setListenerMode(kinesisConsumerProperties.getListenerMode());
-		if (properties.getExtension().isEmbedHeaders()) {
+		if (properties.getExtension().isEmbedHeaders() && !properties.isUseNativeDecoding()) {
 			adapter.setEmbeddedHeadersMapper(this.embeddedHeadersMapper);
 		}
 

--- a/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/KinesisConsumerProperties.java
+++ b/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/KinesisConsumerProperties.java
@@ -93,7 +93,7 @@ public class KinesisConsumerProperties {
 	 */
 	private long gracefulShutdownTimeout;
 
-	private boolean embedHeaders;
+	private boolean embedHeaders = true;
 
 	/**
 	 * The {@link MetricsLevel} for emitting (or not) metrics into Cloud Watch.

--- a/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/KinesisProducerProperties.java
+++ b/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/properties/KinesisProducerProperties.java
@@ -38,7 +38,7 @@ public class KinesisProducerProperties {
 	/**
 	 * Whether to embed headers into Kinesis record.
 	 */
-	private boolean embedHeaders;
+	private boolean embedHeaders = true;
 
 	/**
 	 * The bean name of a MessageChannel to which successful send results should be sent.

--- a/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/provisioning/KinesisStreamProvisioner.java
+++ b/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/provisioning/KinesisStreamProvisioner.java
@@ -86,11 +86,6 @@ public class KinesisStreamProvisioner implements
 		KinesisProducerProperties kinesisProducerProperties = properties.getExtension();
 		kinesisProducerProperties.setEmbedHeaders(
 				properties.getHeaderMode() == null || HeaderMode.embeddedHeaders.equals(properties.getHeaderMode()));
-		properties.setHeaderMode(HeaderMode.none);
-
-		if (properties.getHeaderMode() == null) {
-			properties.setHeaderMode(HeaderMode.embeddedHeaders);
-		}
 
 		return new KinesisProducerDestination(name, createOrUpdate(name, properties.getPartitionCount()));
 	}
@@ -103,7 +98,6 @@ public class KinesisStreamProvisioner implements
 		KinesisConsumerProperties kinesisConsumerProperties = properties.getExtension();
 		kinesisConsumerProperties.setEmbedHeaders(
 				properties.getHeaderMode() == null || HeaderMode.embeddedHeaders.equals(properties.getHeaderMode()));
-		properties.setHeaderMode(HeaderMode.none);
 		int shardCount = properties.getInstanceCount() * properties.getConcurrency();
 
 		if (!properties.isMultiplex()) {

--- a/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/provisioning/KinesisStreamProvisioner.java
+++ b/spring-cloud-stream-binder-kinesis/src/main/java/org/springframework/cloud/stream/binder/kinesis/provisioning/KinesisStreamProvisioner.java
@@ -84,8 +84,9 @@ public class KinesisStreamProvisioner implements
 		}
 
 		KinesisProducerProperties kinesisProducerProperties = properties.getExtension();
-		kinesisProducerProperties.setEmbedHeaders(
-				properties.getHeaderMode() == null || HeaderMode.embeddedHeaders.equals(properties.getHeaderMode()));
+		if (kinesisProducerProperties.isEmbedHeaders()) {
+			properties.setHeaderMode(HeaderMode.none);
+		}
 
 		return new KinesisProducerDestination(name, createOrUpdate(name, properties.getPartitionCount()));
 	}
@@ -96,8 +97,10 @@ public class KinesisStreamProvisioner implements
 			throws ProvisioningException {
 
 		KinesisConsumerProperties kinesisConsumerProperties = properties.getExtension();
-		kinesisConsumerProperties.setEmbedHeaders(
-				properties.getHeaderMode() == null || HeaderMode.embeddedHeaders.equals(properties.getHeaderMode()));
+		if (kinesisConsumerProperties.isEmbedHeaders()) {
+			properties.setHeaderMode(HeaderMode.none);
+		}
+
 		int shardCount = properties.getInstanceCount() * properties.getConcurrency();
 
 		if (!properties.isMultiplex()) {

--- a/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/KinesisBinderFunctionalTests.java
+++ b/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/KinesisBinderFunctionalTests.java
@@ -62,11 +62,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE,
 		properties = {
 				"spring.cloud.stream.bindings.eventConsumerBatchProcessingWithHeaders-in-0.consumer.multiplex=true",
-				"spring.cloud.stream.bindings.eventConsumerBatchProcessingWithHeaders-in-0.destination=some_other_stream, " + KinesisBinderFunctionalTests.KINESIS_STREAM,
+				"spring.cloud.stream.bindings.eventConsumerBatchProcessingWithHeaders-in-0.destination=some_other_stream," + KinesisBinderFunctionalTests.KINESIS_STREAM,
 				"spring.cloud.stream.kinesis.bindings.eventConsumerBatchProcessingWithHeaders-in-0.consumer.idleBetweenPolls = 1",
 				"spring.cloud.stream.kinesis.bindings.eventConsumerBatchProcessingWithHeaders-in-0.consumer.listenerMode = batch",
 				"spring.cloud.stream.kinesis.bindings.eventConsumerBatchProcessingWithHeaders-in-0.consumer.checkpointMode = manual",
-				"spring.cloud.stream.bindings.eventConsumerBatchProcessingWithHeaders-in-0.consumer.useNativeDecoding = true",
+				"spring.cloud.stream.kinesis.bindings.eventConsumerBatchProcessingWithHeaders-in-0.consumer.embedHeaders = false",
 				"spring.cloud.stream.kinesis.binder.headers = event.eventType",
 				"spring.cloud.stream.kinesis.binder.autoAddShards = true"})
 @DirtiesContext

--- a/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/provisioning/KinesisStreamProvisionerTests.java
+++ b/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/provisioning/KinesisStreamProvisionerTests.java
@@ -26,6 +26,7 @@ import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
 
 import org.springframework.cloud.stream.binder.ExtendedConsumerProperties;
 import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
+import org.springframework.cloud.stream.binder.HeaderMode;
 import org.springframework.cloud.stream.binder.kinesis.LocalstackContainerTest;
 import org.springframework.cloud.stream.binder.kinesis.properties.KinesisBinderConfigurationProperties;
 import org.springframework.cloud.stream.binder.kinesis.properties.KinesisConsumerProperties;
@@ -91,6 +92,7 @@ class KinesisStreamProvisionerTests implements LocalstackContainerTest {
 
 		ExtendedConsumerProperties<KinesisConsumerProperties> extendedConsumerProperties =
 				new ExtendedConsumerProperties<>(new KinesisConsumerProperties());
+		extendedConsumerProperties.setHeaderMode(HeaderMode.embeddedHeaders);
 
 		String group = "test-group";
 		ConsumerDestination destination =
@@ -99,6 +101,8 @@ class KinesisStreamProvisionerTests implements LocalstackContainerTest {
 		assertThat(destination.getName()).isEqualTo(streamName);
 		assertThat(destination).isInstanceOf(KinesisConsumerDestination.class);
 		assertThat(destination).extracting("shards").asList().hasSize(1);
+		assertThat(extendedConsumerProperties.getExtension().isEmbedHeaders()).isTrue();
+		assertThat(extendedConsumerProperties.getHeaderMode()).isEqualTo(HeaderMode.embeddedHeaders);
 	}
 
 	@Test

--- a/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/provisioning/KinesisStreamProvisionerTests.java
+++ b/spring-cloud-stream-binder-kinesis/src/test/java/org/springframework/cloud/stream/binder/kinesis/provisioning/KinesisStreamProvisionerTests.java
@@ -102,7 +102,7 @@ class KinesisStreamProvisionerTests implements LocalstackContainerTest {
 		assertThat(destination).isInstanceOf(KinesisConsumerDestination.class);
 		assertThat(destination).extracting("shards").asList().hasSize(1);
 		assertThat(extendedConsumerProperties.getExtension().isEmbedHeaders()).isTrue();
-		assertThat(extendedConsumerProperties.getHeaderMode()).isEqualTo(HeaderMode.embeddedHeaders);
+		assertThat(extendedConsumerProperties.getHeaderMode()).isEqualTo(HeaderMode.none);
 	}
 
 	@Test


### PR DESCRIPTION
When provisioning a stream consumer or producer the passed in binder properties get overwritten with HeaderMode.none.
The issue arises when using multiple destinations (i.e. a default function router for two streams) and not using multiplexing where in such case only the first stream will be able to parse/write the headers.